### PR TITLE
Add validation for timestamps

### DIFF
--- a/src/checker.py
+++ b/src/checker.py
@@ -1,7 +1,7 @@
 import os
 import glob
 
-from .utils import read_avro
+from .utils import read_avro, validate_timestamp  # noqa: F401
 
 
 def check_assert(expr, data):

--- a/src/utils.py
+++ b/src/utils.py
@@ -30,6 +30,8 @@ def validate_timestamp(timestamp, territory=None):
     :param territory: Territory/Region. Needed to check whether a timezone should be
       expected or not in the timestamp, defaults to None
     :type territory: str, default
+    :return: `True` if validated, `False` otherwise
+    :rtype: Bool
     """
     # GB has no timezone attached
     if territory == "GB":

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import fastavro
 
 
@@ -18,3 +19,29 @@ def read_avro(file_path):
             res.append(record)
 
     return res[0]  # we need just one record to run tests
+
+
+def validate_timestamp(timestamp, territory=None):
+    """
+    Validate a timestamp according to
+
+    :param timestamp: A timestamp from the .avro file.
+    :type timestamp: str
+    :param territory: Territory/Region. Needed to check whether a timezone should be
+      expected or not in the timestamp, defaults to None
+    :type territory: str, default
+    """
+    # GB has no timezone attached
+    if territory == "GB":
+        try:
+            datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S.%fZ")
+            return True
+        except ValueError:
+            return False
+
+    # Anything else has hour offsets according to the timezone
+    try:
+        datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S.%f%z")
+        return True
+    except ValueError:
+        return False


### PR DESCRIPTION
Checks on timestamps can be implemented in the `.json` in the following way:
```json
"validate_timestamp(data['activityTimestamp'], data['sdpSourceTerritory'])",
```
