### PR TITLE
Add option to export .json files

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,17 @@ pip install .
 
 ```sh
 $ dif-checker -h
-usage: dif-checker [-h] AVRO_PATH CHECKS_FILE
+usage: dif-checker [-h] [--export-json] AVRO_PATH CHECKS_FILE
+
+Run tests on .avro DIF file
 
 positional arguments:
-  AVRO_PATH    Path of the folder containing .avro files from DIF pipeline
-  CHECKS_FILE  .json file containing checks for feeds in AVRO_PATH
+  AVRO_PATH      Path of the folder containing .avro files from DIF pipeline
+  CHECKS_FILE    .json file containing checks for feeds in AVRO_PATH
 
 optional arguments:
-  -h, --help   show this help message and exit
+  -h, --help     show this help message and exit
+  --export-json  Export .avro feeds in json format for further checks
 ```
 
 The `dif-checker` command relies on a folder containing `.avro` files and a `.json` listing checks that will be

--- a/src/checker.py
+++ b/src/checker.py
@@ -28,7 +28,7 @@ def check_assert(expr, data):
         return False
 
 
-def run_checks(avro_folder, configs):
+def run_checks(avro_folder, configs, export_json=False):
     """
     Traverses a config dict and run checks iteratively
 
@@ -59,5 +59,8 @@ def run_checks(avro_folder, configs):
                         res_counter["passed"] += 1
                     else:
                         res_counter["failed"] += 1
+
+                if export_json:
+                    utils.export_json(data, file)
 
     return res_counter

--- a/src/checker_cli.py
+++ b/src/checker_cli.py
@@ -37,7 +37,7 @@ def get_args():
     parser.add_argument(
         "--export-json",
         required=False,
-        help="Export .avro feeds in json format",
+        help="Export .avro feeds in json format for further checks",
         action="store_true",
         default=False,
     )

--- a/src/checker_cli.py
+++ b/src/checker_cli.py
@@ -10,7 +10,9 @@ def main():
 
     with open(args.checks_file, "r") as f:
         checks = json.load(f)
-    res = run_checks(avro_path, checks)
+    res = run_checks(avro_path, checks, args.export_json)
+
+    # Print results
     print("")
     print("~" * 50)
     print(f"{bcolors.OKGREEN}PASSED: {res['passed']}{bcolors.ENDC}")
@@ -31,6 +33,13 @@ def get_args():
         type=str,
         metavar="CHECKS_FILE",
         help=".json file containing checks for feeds in AVRO_PATH",
+    )
+    parser.add_argument(
+        "--export-json",
+        required=False,
+        help="Export .avro feeds in json format",
+        action="store_true",
+        default=False,
     )
 
     args = parser.parse_args()

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,4 +1,6 @@
+import os
 from datetime import datetime
+import json
 import fastavro
 
 
@@ -19,6 +21,28 @@ def read_avro(file_path):
             res.append(record)
 
     return res[0]  # we need just one record to run tests
+
+
+def export_json(data, file, output_folder=None):
+    """
+    Export data to .json format
+
+    :param data: A dict containing data to be exported
+    :type data: dict
+    :param file: original .avro filename
+    :type file: str
+    :param output_folder: Folder in which dump .json files
+    :type output_folder: str, optional
+    """
+    filename = os.path.split(file)[1].split(".")[0]
+
+    if output_folder:
+        output_path = os.path.join(output_folder, filename)
+    else:
+        output_path = os.path.join(filename)
+
+    with open(f"{output_path}.json", "w") as f:
+        json.dump(data, f)
 
 
 def validate_timestamp(timestamp, territory=None):


### PR DESCRIPTION
This will add a `--export-json` flag that will let the user to export `.json` files after being converted from `.avro`.